### PR TITLE
Correct profile endpoint documentation

### DIFF
--- a/endpoints_profile.go
+++ b/endpoints_profile.go
@@ -31,7 +31,7 @@ func (c *Client) ListProfileGames() (*ListProfileGamesResponse, error) {
 
 //-------------------------------------------------------
 
-// ListProfileOwnedKeysResponse is the response for /my-owned-keys
+// ListProfileOwnedKeysResponse is the response for /profile/owned-keys
 type ListProfileOwnedKeysResponse struct {
 	OwnedKeys []*DownloadKey `json:"ownedKeys"`
 }
@@ -45,7 +45,7 @@ func (c *Client) ListProfileOwnedKeys() (*ListProfileOwnedKeysResponse, error) {
 
 //-------------------------------------------------------
 
-// ListProfileCollectionsResponse is the response for /my-collections
+// ListProfileCollectionsResponse is the response for /profile/collections
 type ListProfileCollectionsResponse struct {
 	Collections []*Collection `json:"collections"`
 }


### PR DESCRIPTION
The functions that use these responses use different endpoints than the documentation currently describes. Assuming the functions are accurate, this updates the docs to refer to those endpoints.