### PR TITLE
Remove GetUserGameSessionsParams

### DIFF
--- a/endpoints_interactions.go
+++ b/endpoints_interactions.go
@@ -30,13 +30,6 @@ type UserGameSession struct {
 // endpoints
 /////////////////////////////
 
-// GetUserGameSessionsParams : params for GetUserGameSessions
-type GetUserGameSessionsParams struct {
-	GameID int64
-
-	Credentials GameCredentials
-}
-
 type SessionPlatform string
 
 const (


### PR DESCRIPTION
`GetUserGameSessions` has been removed [here](https://github.com/itchio/go-itchio/commit/48572a83f2608a14e94aea88363ca5e41c8ec78f), but the params struct hasn't been removed